### PR TITLE
Fix typos in driver comments

### DIFF
--- a/general/pcidrv/kmdf/HW/nic_pm.c
+++ b/general/pcidrv/kmdf/HW/nic_pm.c
@@ -155,7 +155,7 @@ typedef struct _MP_PM_PCI_SPACE {
 
     UCHAR Stuff[PMC_Offset];
 
-    // PM capabilites
+    // PM capabilities
 
     MP_PM_CAP_REG   PMCaps;
 

--- a/storage/iscsi/src/client/wmisample.c
+++ b/storage/iscsi/src/client/wmisample.c
@@ -2381,7 +2381,7 @@ UCHAR iScsiQuerySecurityCapabilities(
 
 Routine Description :
 
-    This routine implements the WMI query for the security capabilites
+    This routine implements the WMI query for the security capabilities
     class.
 
 --*/

--- a/storage/sfloppy/src/floppy.c
+++ b/storage/sfloppy/src/floppy.c
@@ -583,7 +583,7 @@ Return Value:
 
         //
         // Increment system floppy device count.
-        //
+                        driver describing adapter capabilities (and limitations).
 
         IoGetConfigurationInformation()->FloppyCount++;
     }

--- a/usb/kmdf_fx2/driver/Device.c
+++ b/usb/kmdf_fx2/driver/Device.c
@@ -471,8 +471,8 @@ Return Value:
     }
 
     //
-    // Retrieve USBD version information, port driver capabilites and device
-    // capabilites such as speed, power, etc.
+    // Retrieve USBD version information, port driver capabilities and device
+    // capabilities such as speed, power, etc.
     //
     WDF_USB_DEVICE_INFORMATION_INIT(&deviceInfo);
 

--- a/usb/umdf2_fx2/driver/Device.c
+++ b/usb/umdf2_fx2/driver/Device.c
@@ -404,8 +404,8 @@ Return Value:
     }
 
     //
-    // Retrieve USBD version information, port driver capabilites and device
-    // capabilites such as speed, power, etc.
+    // Retrieve USBD version information, port driver capabilities and device
+    // capabilities such as speed, power, etc.
     //
     WDF_USB_DEVICE_INFORMATION_INIT(&deviceInfo);
 

--- a/usb/umdf_filter_kmdf/kmdf_driver/Device.c
+++ b/usb/umdf_filter_kmdf/kmdf_driver/Device.c
@@ -471,8 +471,8 @@ Return Value:
     }
 
     //
-    // Retrieve USBD version information, port driver capabilites and device
-    // capabilites such as speed, power, etc.
+    // Retrieve USBD version information, port driver capabilities and device
+    // capabilities such as speed, power, etc.
     //
     WDF_USB_DEVICE_INFORMATION_INIT(&deviceInfo);
 

--- a/usb/usbsamp/sys/device.c
+++ b/usb/usbsamp/sys/device.c
@@ -1381,8 +1381,8 @@ RetrieveDeviceInformation(
     WDF_USB_DEVICE_INFORMATION_INIT(&info);
 
     //
-    // Retrieve USBD version information, port driver capabilites and device
-    // capabilites such as speed, power, etc.
+    // Retrieve USBD version information, port driver capabilities and device
+    // capabilities such as speed, power, etc.
     //
     status = WdfUsbTargetDeviceRetrieveInformation(pDeviceContext->WdfUsbTargetDevice,
                                                    &info);

--- a/usb/usbsamp/sys/stream.c
+++ b/usb/usbsamp/sys/stream.c
@@ -77,7 +77,7 @@ Return Value:
     // Note: All super speed bulk stream I/O transfers use USBD Handle obtained in
     //       UsbSamp_EvtDeviceAdd. If you call WdfUsbTargetDeviceQueryUsbCapability
     //       method instead of USBD_QueryUsbCapability here, it will not set stream 
-    //       capabilites for USBD Handle used by stream transfer in which case 
+    //       capabilities for USBD Handle used by stream transfer in which case
     //       the open streams request will fail in this example.
     //
     status = USBD_QueryUsbCapability(pDevContext->UsbdHandle,


### PR DESCRIPTION
## Summary
- correct repeated misspelling of **capabilities** across various driver sources

## Testing
- `grep -R "capabilites" -n | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_684aaf94e81c8327a2f551bcfc8ef176